### PR TITLE
Allow -1 for infinite jobs

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,4 +1,24 @@
 class Job:
+    """Representa un trabajo de medición.
+
+    Parameters
+    ----------
+    node : int
+        Identificador del nodo.
+    num_mediciones : int
+        Número de mediciones a realizar. Un valor ``-1`` indica que el
+        trabajo no tiene un número máximo de mediciones (ejecución
+        indefinida).
+    tiempo : int
+        Duración de cada medición en segundos.
+    delay : int
+        Tiempo de espera entre mediciones.
+    active : int
+        Flag que indica si el job está activo.
+    ai_active : int
+        Flag que indica si se ejecuta análisis IA después de cada medición.
+    """
+
     def __init__(self, node, num_mediciones, tiempo, delay, active, ai_active):
         self.n = node
         self.nm = num_mediciones


### PR DESCRIPTION
## Summary
- update job documentation to specify -1 as the indefinite value
- adjust `run_job` control flow to check for `-1`
- clarify job creation comment about indefinite jobs

## Testing
- `python -m py_compile app.py models.py services/inference_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6858e0ea251083298643d2adccd70de5